### PR TITLE
incoming calls fix

### DIFF
--- a/SIP/SIPBase.cpp
+++ b/SIP/SIPBase.cpp
@@ -1423,11 +1423,11 @@ void SipMTInviteServerTransactionLayer::MTCSendOK(CodecSet wCodec, const L3Logic
 	mRTPPort = allocateRTPPorts();
 	mCodec = wCodec;
 	LOG(INFO) <<sbText();
+	setSipState(Connecting);
 	SipMessageReply ok(invite,200,string("OK"),this);
 	ok.smAddBody(string("application/sdp"),makeSDPAnswer());	// TODO: This should be a reply to the originating SDP offer.
 	writePrivateHeaders(&ok,chan);
 	mtWriteLowSide(&ok);
-	setSipState(Connecting);
 	// In RFC-3261 the Transaction Layer no longer handles timers after the OK is sent.
 	// The Transport Layer alone is not capabable of sending the 200 OK reliably because then the
 	// INVITE server transaction ends, and the INVITE client transaction no longer resends INVITEs after
@@ -1519,7 +1519,7 @@ bool SipMTInviteServerTransactionLayer::mtPeriodicService()
 {
 	if (mTimerG.expired()) {	// Resend timer.
 		if (getSipState() == SSFail || getSipState() == Active) {
-			sipWrite(mLastResponse);
+			sipWrite(&mtLastResponse);
 			mTimerG.setDouble(T2);	// Will send again later.
 		} else {
 			// This could happen if a CANCEL started before the ACK was received.


### PR DESCRIPTION
This is the proposed fix, all that frustration caused by two measly lines :disappointed:  

This will need to be tested on the box tomorrow which is in the office, but I don't see any reason why it shouldn't work.

First line fix is to prevent the race condition caused when we get an ACK too quickly after sending the OK and jump straight into Active before transitioning into Connecting. 

Second line is because of the segfault I was getting. Trying to send the lastResponse variable which is for MOCs while in an MTC. Not sure what is happening in that method though haha.

If anything looks evil, let me know. I'll also PR on the public openbts