### PR TITLE
tmsis -r now shows times as seconds since epoch

### DIFF
--- a/Control/TMSITable.cpp
+++ b/Control/TMSITable.cpp
@@ -819,13 +819,22 @@ vector< vector<string> > TMSITable::tmsiTabView(int verbosity, bool rawFlag, uns
 				}
 			} else if (header == "CREATED" || header == "ACCESSED") {
 				// Print seconds as a time value.
-				row.push_back(prettyAge(now - query.getResultInt(col)));
+				unsigned timeDelta = now - query.getResultInt(col);
+				if (rawFlag) {
+					row.push_back(format("%d",timeDelta));
+ 				} else {
+					row.push_back(prettyAge(timeDelta));
+ 				}
 			} else if (header == "AUTH_EXPIRY") {
 				// The expiry is the absolute time when it expires, or 0 if unknown.
 				int expiry = query.getResultInt(col);
 				int remaining = expiry - now;
 				if (remaining < 0) remaining = 0;
-				row.push_back(expiry ? prettyAge(remaining) : "-");
+				if (rawFlag) {
+					row.push_back(format("%d", remaining));
+ 				} else {
+					row.push_back(expiry ? prettyAge(remaining) : "-");
+ 				}
 			} else {
 				// All other column types.  If they are integer they are converted to "" if NULL else decimal.
 				row.push_back(query.getResultText(col));


### PR DESCRIPTION
In requesting the raw TMSI table output, give times as seconds since the epoch rather than `prettyAge`d times