### PR TITLE
Fix several stack buffer overflows in sendCommand variants

### DIFF
--- a/TRXManager/TRXManager.cpp
+++ b/TRXManager/TRXManager.cpp
@@ -320,9 +320,8 @@ int ::ARFCNManager::sendCommand(const char*command, const char*param, int *respo
 	int rspLen = sendCommandPacket(cmdBuf,response);
 	if (rspLen<=0) return -1;
 	// Parse and check status.
-	char cmdNameTest[15];
+	char cmdNameTest[16] = { 0 };
 	int status;
-	cmdNameTest[0]='\0';
         if (!responseParam)
 	  sscanf(response,"RSP %15s %d", cmdNameTest, &status);
         else
@@ -340,9 +339,8 @@ int ::ARFCNManager::sendCommand(const char*command, int param, int *responsePara
 	int rspLen = sendCommandPacket(cmdBuf,response);
 	if (rspLen<=0) return -1;
 	// Parse and check status.
-	char cmdNameTest[15];
+	char cmdNameTest[16] = { 0 };
 	int status;
-	cmdNameTest[0]='\0';
         if (!responseParam)
 	  sscanf(response,"RSP %15s %d", cmdNameTest, &status);
         else
@@ -361,9 +359,8 @@ int ::ARFCNManager::sendCommand(const char*command, const char* param)
 	int rspLen = sendCommandPacket(cmdBuf,response);
 	if (rspLen<=0) return -1;
 	// Parse and check status.
-	char cmdNameTest[15];
+	char cmdNameTest[16] = { 0 };
 	int status;
-	cmdNameTest[0]='\0';
 	sscanf(response,"RSP %15s %d", cmdNameTest, &status);
 	if (strcmp(cmdNameTest,command)!=0) return -1;
 	return status;
@@ -380,9 +377,8 @@ int ::ARFCNManager::sendCommand(const char*command)
 	int rspLen = sendCommandPacket(cmdBuf,response);
 	if (rspLen<=0) return -1;
 	// Parse and check status.
-	char cmdNameTest[15];
+	char cmdNameTest[16] = { 0 };
 	int status;
-	cmdNameTest[0]='\0';
 	sscanf(response,"RSP %15s %d", cmdNameTest, &status);
 	if (strcmp(cmdNameTest,command)!=0) return -1;
 	return status;


### PR DESCRIPTION
First of taking open range PRs and applying them to our repo. This one seems fine, fixes array init. 