### PR TITLE
This makes it so that NodeManager calls to tmsis uses JSONDB

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -41,6 +41,7 @@ CLI_INCLUDEDIR = $(top_srcdir)/CLI
 PEERING_INCLUDEDIR = $(top_srcdir)/Peering
 NODEMANAGER_INCLUDEDIR = $(top_srcdir)/NodeManager
 JSONBOX_INCLUDEDIR = $(top_srcdir)/NodeManager/JsonBox-0.4.3/include
+JSONDB_INCLUDEDIR = $(top_srcdir)/NodeManager/JSONDB
 SCANNING_INCLUDEDIR = $(top_srcdir)/Scanning
 APPS_INCLUDEDIR = $(top_srcdir)/apps
 
@@ -63,6 +64,7 @@ STD_DEFINES_AND_INCLUDES = $(GPROF_OPTIONS) \
 	-I$(PEERING_INCLUDEDIR) \
 	-I$(NODEMANAGER_INCLUDEDIR) \
 	-I$(JSONBOX_INCLUDEDIR) \
+	-I$(JSONDB_INCLUDEDIR) \
 	-I$(SCANNING_INCLUDEDIR)
 
 # These macros are referenced in apps/Makefile.am, which must be changed in sync with these.

--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -49,7 +49,7 @@ ourlibs = \
 	$(NODEMANAGER_LA) \
 	$(ORTP_LIBS)
 
-OpenBTS_SOURCES = OpenBTS.cpp GetConfigurationKeys.cpp
+OpenBTS_SOURCES = OpenBTS.cpp GetConfigurationKeys.cpp ../NodeManager/JSONDB/JSONDB.cpp
 OpenBTS_LDADD = $(ourlibs) -lcrypto -lssl -ldl -lortp -la53 -lcoredumper 
 OpenBTS_LDFLAGS = $(GPROF_OPTIONS) -rdynamic
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,18 @@
+openbts-public (5.0.2) unstable; urgency=medium
+
+  * uses JSONDB for the tmsis command in NodeManager - 23157c32
+
+ -- Endaga BuildBot <buildbot@endaga.com>  Tue, 23 Jun 2015 15:15:23 -0700
+
+openbts-public (5.0.1) unstable; urgency=medium
+
+  * fixes deadlock - ed436d40
+
+ -- Endaga BuildBot <buildbot@endaga.com>  Tue, 23 Jun 2015 18:20:08 +0000
+
 openbts-public (5.0) unstable; urgency=low
 
     * Test
 
  -- Range Packager <buildmanager@rangenetworks.com>  Mon, 15 Sep 2014 17:42:42 -0700
+


### PR DESCRIPTION
PTAL 

The previous implementation spat out everything and didn't allow for
filtering on SQL. This should make calls a little more efficient.