### PR TITLE
Fix bug with command lengths over 127

### DIFF
--- a/CLI/CLIServer.cpp
+++ b/CLI/CLIServer.cpp
@@ -202,7 +202,7 @@ void Parser::cliServer()
 						close(i);
 						continue; // go to next socket
 					}
-					if (len < (int) sizeof(len)) // should never get here
+					if (nread < (int) sizeof(len)) // should never get here
 					{
 						char buf[BUFSIZ];
 						sprintf(buf, "Unable to read complete length, s.b. %d bytes, got %d bytes\n", sizeof(len), len);


### PR DESCRIPTION
Small bug fix to CLI parsing. Orphaned range patch. 