### PR TITLE
proper existing entry check

### DIFF
--- a/Control/TMSITable.cpp
+++ b/Control/TMSITable.cpp
@@ -480,8 +480,7 @@ uint32_t TMSITable::tmsiTabCreateOrUpdate(
 	ScopedLock lock(sTmsiMutex,__FILE__,__LINE__); // This lock should be redundant - sql serializes access, but it may prevent sql retry failures.
 
 	unsigned oldRawTmsi = tmsiTabGetTMSI(imsi,false);
-	bool isAuthed = tmsiTabCheckAuthorization(imsi);
-	bool isNewRecord = (isAuthed == 0);
+	bool isNewRecord = !sqlite3_exists(mTmsiDB,"TMSI_TABLE","IMSI",imsi.c_str());
 
 	TSqlQuery *queryp;	// dufus language
 	TSqlInsert foo;


### PR DESCRIPTION
This addresses TMSI insert errors when `AUTH=0`:


```
Jul 23 03:18:40 openbts: ERR 2597:2623 2015-07-23T03:18:40.7 sqlite3util.cpp:83:sqlite3_run_query: sqlite3_run_query failed code=19 for: INSERT INTO TMSI_TABLE (IMSI,CREATED,ACCESSED,TMSI,IMEI,AUTH,REJECT_CODE,OLD_MCC,OLD_MNC,OLD_LAC,OLD_TMSI) VALUES ('510104332469457',1437621520,1437621520,1073742107,'353331478077960',0,13,510,10,65534,0): UNIQUE constraint failed: TMSI_TABLE.IMSI
Jul 23 03:18:40 openbts: ERR 2597:2623 2015-07-23T03:18:40.7 TMSITable.cpp:165:runQuery: TMSI table query: query=INSERT INTO TMSI_TABLE (IMSI,CREATED,ACCESSED,TMSI,IMEI,AUTH,REJECT_CODE,OLD_MCC,OLD_MNC,OLD_LAC,OLD_TMSI) VALUES ('510104332469457',1437621520,1437621520,1073742107,'353331478077960',0,13,510,10,65534,0) resultCode=19 changes=0 error:UNIQUE constraint failed: TMSI_TABLE.IMSI
Jul 23 03:18:40 openbts: ALERT 2597:2623 2015-07-23T03:18:40.7 TMSITable.cpp:538:tmsiTabCreateOrUpdate: TMSI creation failed for imsi=510104332469457 query:INSERT INTO TMSI_TABLE (IMSI,CREATED,ACCESSED,TMSI,IMEI,AUTH,REJECT_CODE,OLD_MCC,OLD_MNC,OLD_LAC,OLD_TMSI) VALUES ('510104332469457',1437621520,1437621520,1073742107,'353331478077960',0,13,510,10,65534,0)
```

WIP.. This hasn't been tested