### PR TITLE
Use https url instead of git for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "CommonLibs"]
 	path = CommonLibs
-	url = git@github.com:endaga/CommonLibs.git
+	url = https://github.com/endaga/CommonLibs.git
 	branch = master
 [submodule "sqlite3"]
 	path = sqlite3
-	url = git@github.com:RangeNetworks/sqlite3.git
+	url = https://github.com/RangeNetworks/sqlite3.git
 	branch = master
 [submodule "NodeManager"]
 	path = NodeManager


### PR DESCRIPTION
I was having trouble integrating openbts in a Yocto recipe (gitsm fetcher authentication was failing). Using the https url fixes the issue.